### PR TITLE
Patch 1

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -30,7 +30,27 @@ require([ 'gitbook' ], function (gitbook) {
 			label: 'Edit on GitHub',
 			position: 'right',
 			onClick: function() {
-				window.open('https://github.com/' + defaultOption.repo + '/edit/' + defaultOption.branch + '/' + gitbook.state.filepath);
+				
+				let editUrl = 'https://github.com/' + defaultOption.repo + '/edit/' + defaultOption.branch + '/';
+				let docsRoot = defaultOption.root;
+				if(docsRoot){
+					
+					//removes ./ at the beginning, if any
+					if(docsRoot.startsWith('./')){
+						docsRoot = docsRoot.substr(2);
+					}
+					
+					//removes trailing /, if any
+					if(docsRoot.endsWith('/')){
+						docsRoot = docsRoot.substr(0, docsRoot.length - 1);
+					}
+					
+					editUrl += docsRoot;
+				}
+				
+				editUrl += ('/' + gitbook.state.filepath);
+				
+				window.open(editUrl);
 			}
 		});
 	};

--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -32,7 +32,7 @@ require([ 'gitbook' ], function (gitbook) {
 			onClick: function() {
 				
 				let editUrl = 'https://github.com/' + defaultOption.repo + '/edit/' + defaultOption.branch + '/';
-				let docsRoot = defaultOption.root;
+				let docsRoot = config.root;
 				if(docsRoot){
 					
 					//removes ./ at the beginning, if any


### PR DESCRIPTION
Connects to https://github.com/aleen42/PersonalWiki/issues/25

I decided to give it a try. Be aware that my knowledge of `nod.js` is zero and GitBook plugin programming model is very limited.

GitBook allows to define a `root` configuration option in the `book.json` file to specify that doco source files are stored in a sub-folder and not directly in the repository root folder.

This PR aims to introduce support for it in the `gitbook-edit` plugin.