### PR TITLE
Rm gitbook dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
         "title": "which branch do you want users to edit"
       }
     }
-  },
-  "dependencies": {
-    "gitbook": "3.2.2"
   }
 }


### PR DESCRIPTION
Is it actually necessary to stipulate `gitbook` as a dependency for this plugin?  It seems that none of Gitbook's plugins do this:

* https://github.com/GitbookIO/plugin-mathjax/blob/master/package.json#L11-L15
* https://github.com/GitbookIO/plugin-autocover/blob/master/package.json#L12-L18
* https://github.com/GitbookIO/plugin-exercises/blob/master/package.json#L6-L11

It (strangely) makes my `gitbook install` command last a LONG time (like 30 minutes), although this may be an entirely personal issue (not sure what would cause this, but I don't experience it with any other plugins).